### PR TITLE
判定ラベルの表記修正と完了サマリへの判定結果追加

### DIFF
--- a/axios_audit_run_all.ps1
+++ b/axios_audit_run_all.ps1
@@ -381,6 +381,39 @@ foreach ($sr in $stageResults) {
 }
 
 Write-Host ''
+
+# 判定結果サマリ
+$verdictCsvFinal = Join-Path $outputDir 'AuditVerdict.csv'
+$iocCsvFinal = Join-Path $outputDir 'IocFindings.csv'
+if (Test-Path $verdictCsvFinal) {
+    $vRowsFinal = Import-Csv $verdictCsvFinal
+    $cCompromised  = @($vRowsFinal | Where-Object { $_.Verdict -eq 'Compromised' }).Count
+    $cNeedsReview  = @($vRowsFinal | Where-Object { $_.Verdict -eq 'NeedsReview' }).Count
+    $cHardening    = @($vRowsFinal | Where-Object { $_.Verdict -eq 'Hardening' }).Count
+    $cClean        = @($vRowsFinal | Where-Object { $_.Verdict -eq 'Clean' }).Count
+    $cHighIoc = 0
+    if (Test-Path $iocCsvFinal) {
+        $cHighIoc = @(Import-Csv $iocCsvFinal | Where-Object { $_.Severity -eq 'High' }).Count
+    }
+
+    Write-Host '  --------------------------------------------------------' -ForegroundColor DarkGray
+    Write-Host '  判定結果:' -ForegroundColor Cyan
+    Write-Host ''
+    if ($cCompromised -eq 0 -and $cHighIoc -eq 0) {
+        Write-Host '    侵害は検出されませんでした' -ForegroundColor Green
+    } else {
+        Write-Host '    侵害が検出されました' -ForegroundColor Red
+    }
+    Write-Host ''
+    Write-Host "    侵害確定:   $cCompromised 件" -ForegroundColor $(if ($cCompromised -gt 0) { 'Red' } else { 'Green' })
+    Write-Host "    要確認:     $cNeedsReview 件" -ForegroundColor $(if ($cNeedsReview -gt 0) { 'Yellow' } else { 'Green' })
+    Write-Host "    要強化:     $cHardening 件" -ForegroundColor $(if ($cHardening -gt 0) { 'Yellow' } else { 'Green' })
+    Write-Host "    対策不要:   $cClean 件" -ForegroundColor Green
+    Write-Host "    システム IOC: $cHighIoc 件" -ForegroundColor $(if ($cHighIoc -gt 0) { 'Red' } else { 'Green' })
+    Write-Host ''
+    Write-Host '  --------------------------------------------------------' -ForegroundColor DarkGray
+}
+
 Write-Host ('  結果フォルダ: ' + $outputDir) -ForegroundColor White
 Write-Host ''
 

--- a/axios_audit_stage6_verdict.ps1
+++ b/axios_audit_stage6_verdict.ps1
@@ -208,7 +208,7 @@ if ($systemCompromised) {
 [void]$report.Add("  - 侵害確定:   $countCompromised 件")
 [void]$report.Add("  - 要確認:     $countNeedsReview 件")
 [void]$report.Add("  - 要強化:     $countHardening 件")
-[void]$report.Add("  - 白寄り:     $countClean 件")
+[void]$report.Add("  - 対策不要:   $countClean 件")
 [void]$report.Add("  - システム IOC: $($highIocs.Count) 件")
 if (-not $wslExists) {
     [void]$report.Add("  - WSL 確認:    未実施（Stage 5 未実行）")
@@ -244,12 +244,12 @@ foreach ($v in ($verdictResults | Sort-Object Verdict, Path)) {
         'Compromised' { '[侵害確定]' }
         'NeedsReview' { '[要確認]  ' }
         'Hardening'   { '[要強化]  ' }
-        'Clean'       { '[白]      ' }
+        'Clean'       { '[対策不要]' }
     }
     $ownerTag = switch ($v.Ownership) {
-        'Mine'       { '(自分)' }
-        'ThirdParty' { '(他者)' }
-        default      { '(不明)' }
+        'Mine'       { '(自作)' }
+        'ThirdParty' { '(他作)' }
+        default      { '(作者不明)' }
     }
     [void]$report.Add("  $icon $ownerTag $($v.Path)")
     if ($v.Reasons) {
@@ -395,7 +395,7 @@ Write-Host ''
 Write-Host "  侵害確定: $countCompromised 件" -ForegroundColor $(if ($countCompromised -gt 0) { 'Red' } else { 'Green' })
 Write-Host "  要確認:   $countNeedsReview 件" -ForegroundColor $(if ($countNeedsReview -gt 0) { 'Yellow' } else { 'Green' })
 Write-Host "  要強化:   $countHardening 件" -ForegroundColor $(if ($countHardening -gt 0) { 'Yellow' } else { 'Green' })
-Write-Host "  白寄り:   $countClean 件" -ForegroundColor Green
+Write-Host "  対策不要: $countClean 件" -ForegroundColor Green
 Write-Host "  IOC:      $($highIocs.Count) 件" -ForegroundColor $(if ($highIocs.Count -gt 0) { 'Red' } else { 'Green' })
 Write-Host ''
 if ($systemCompromised -or $countCompromised -gt 0) {


### PR DESCRIPTION
## Summary
- Stage 6 の判定ラベルを分かりやすい表記に修正（`[白]`→`[対策不要]`、`(自分)`→`(自作)` 等）
- `run_all.ps1` の監査完了表示に判定結果サマリ（侵害確定/要確認/要強化/対策不要/IOC件数）を追加し、侵害の有無を明示

## Test plan
- [ ] Stage 6 実行後の `AuditVerdict.txt` で `[対策不要]` `(自作)` `(他作)` `(作者不明)` 表記になっていること
- [ ] `run_all.ps1` 完了時に判定結果サマリが表示されること
- [ ] 侵害未検出時に「侵害は検出されませんでした」と表示されること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)