### PR TITLE
Stage 6: 安全確認済み axios の誤った要確認判定を修正

### DIFF
--- a/axios_audit_stage6_verdict.ps1
+++ b/axios_audit_stage6_verdict.ps1
@@ -103,8 +103,17 @@ foreach ($path in ($allPaths.Keys | Sort-Object)) {
             [void]$reasons.Add("関連侵害パッケージ ($($mf.Pattern)) が見つかりました")
         }
         if ($mf.Severity -eq 'NeedsReview' -and $mf.Pattern -match 'node_modules.*axios') {
-            if ($verdict -eq 'Clean') { $verdict = 'NeedsReview' }
-            [void]$reasons.Add("node_modules/axios が存在（バージョン確認が必要）")
+            $axiosConfirmedSafe = $false
+            foreach ($vf in @($versions | Where-Object { $_.RepoPath -eq $path })) {
+                if ($vf.Status -eq 'ObservedVersion' -or $vf.Status -eq 'NoAxiosResolved') {
+                    $axiosConfirmedSafe = $true
+                    break
+                }
+            }
+            if (-not $axiosConfirmedSafe) {
+                if ($verdict -eq 'Clean') { $verdict = 'NeedsReview' }
+                [void]$reasons.Add("node_modules/axios が存在（バージョン確認が必要）")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- lockfile に `node_modules/axios` の記述があるだけで `[要確認]` になっていた問題を修正
- Stage 3 でバージョンが安全と確認済み (`ObservedVersion`) または axios 未インストール (`NoAxiosResolved`) の場合は `NeedsReview` にしない
- npm が利用不可・エラーの場合は引き続き `[要確認]` とする

## Test plan
- [ ] `-StartFrom 6` で再実行し、安全なバージョンの axios を持つプロジェクトが `[要確認]` から `[対策不要]` または `[要強化]` に変わること
- [ ] npm が利用不可のプロジェクトは引き続き `[要確認]` のままであること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)