### PR TITLE
Stage 6: サブプロジェクトのパス不一致による誤った要確認判定を修正

### DIFF
--- a/axios_audit_stage6_verdict.ps1
+++ b/axios_audit_stage6_verdict.ps1
@@ -104,7 +104,10 @@ foreach ($path in ($allPaths.Keys | Sort-Object)) {
         }
         if ($mf.Severity -eq 'NeedsReview' -and $mf.Pattern -match 'node_modules.*axios') {
             $axiosConfirmedSafe = $false
-            foreach ($vf in @($versions | Where-Object { $_.RepoPath -eq $path })) {
+            # 完全一致またはサブディレクトリの Stage 3 結果も含めて確認
+            # （親リポジトリの RepoPath と worktree 等の子パスの粒度が異なるため）
+            $pathWithSep = $path.TrimEnd('\') + '\'
+            foreach ($vf in @($versions | Where-Object { $_.RepoPath -eq $path -or $_.RepoPath.StartsWith($pathWithSep) })) {
                 if ($vf.Status -eq 'ObservedVersion' -or $vf.Status -eq 'NoAxiosResolved') {
                     $axiosConfirmedSafe = $true
                     break


### PR DESCRIPTION
## Summary
- Stage 3 は worktree 等のサブディレクトリ単位でバージョン確認するが、Stage 6 は親リポジトリの RepoPath で verdict を集約するため、パスの粒度が一致せず安全確認済みの結果が参照できていなかった
- サブディレクトリ（`path\` で始まるパス）の Stage 3 結果も含めて検索するよう修正
- `dynamic_kamuicode`, `kamuicode_20250811`, `kamuicode_nanobanana` 等の誤った `[要確認]` が解消される

## Test plan
- [ ] `-StartFrom 6` で再実行し、上記3プロジェクトが `[要確認]` でなくなること
- [ ] 実際に npm が利用不可のプロジェクトは引き続き `[要確認]` のままであること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)