### PR TITLE
min-release-age の案内に npm バージョン条件を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ powershell -ExecutionPolicy Bypass -File .\axios_audit_run_all.ps1 -StartFrom 7 
 powershell -ExecutionPolicy Bypass -File .\axios_audit_run_all.ps1 -StartFrom 7 -AutoRemediate
 ```
 
+## 注意事項
+
+- Stage 7/8（侵害検出時の修復・検証）は、実際の侵害環境での動作検証を行っていません。修復を実行する前に、必ず `-DryRunOnly` で内容を確認してください。
+- 本ツールは侵害の有無を判定する補助ツールであり、検出結果の最終判断はご自身で行ってください。
+
 ## 詳細マニュアル
 
 攻撃の背景、各 Stage の詳しい説明、判定結果の読み方、修復後の手動対応、今後の防御策については **[axios_audit_manual.md](axios_audit_manual.md)** を参照してください。

--- a/axios_audit_manual.md
+++ b/axios_audit_manual.md
@@ -566,6 +566,27 @@ npx can-i-ignore-scripts
 npm install パッケージ名 --min-release-age=0
 ```
 
+### Q. `npm config set min-release-age 7` がエラーになります。
+
+`min-release-age` は npm v11.10 以降で追加された機能です。お使いの npm が古い場合はエラーになります。
+
+```
+npm --version
+```
+
+でバージョンを確認し、古い場合は Node.js ごとアップグレードしてください：
+
+```
+# Node.js 公式サイトから LTS 版をインストール（npm も同梱）
+https://nodejs.org/
+
+# または nvm-windows を使っている場合
+nvm install lts
+nvm use lts
+```
+
+アップグレード後に再度 `npm config set min-release-age 7` を実行してください。なお、`min-release-age` が使えなくても `ignore-scripts true` だけで今回の攻撃は防げます。両方設定するのが理想ですが、まずは `ignore-scripts` を優先してください。
+
 ---
 
 ## 既知の制限

--- a/axios_audit_run_all.ps1
+++ b/axios_audit_run_all.ps1
@@ -456,23 +456,42 @@ if ($ignoreOk) {
 } else {
     Write-Host ('    ignore-scripts  = ' + $(if ($cfgIgnore) { $cfgIgnore } else { '(未設定)' }) + '  ✗ 未設定') -ForegroundColor Yellow
 }
-if ($ageOk) {
-    Write-Host ('    min-release-age = ' + $cfgAge + '      ✓') -ForegroundColor Green
+# npm バージョンを取得して min-release-age の対応可否を判定
+$npmVersionStr = $null
+try { $npmVersionStr = (& npm --version 2>$null) } catch {}
+$npmSupportsAge = $false
+if ($npmVersionStr -match '^(\d+)\.(\d+)') {
+    $npmMajor = [int]$Matches[1]; $npmMinor = [int]$Matches[2]
+    $npmSupportsAge = ($npmMajor -gt 11 -or ($npmMajor -eq 11 -and $npmMinor -ge 10))
+}
+
+if ($npmSupportsAge) {
+    if ($ageOk) {
+        Write-Host ('    min-release-age = ' + $cfgAge + '      ✓') -ForegroundColor Green
+    } else {
+        Write-Host ('    min-release-age = ' + $(if ($cfgAge) { $cfgAge } else { '(未設定)' }) + '  ✗ 未設定') -ForegroundColor Yellow
+    }
 } else {
-    Write-Host ('    min-release-age = ' + $(if ($cfgAge) { $cfgAge } else { '(未設定)' }) + '  ✗ 未設定') -ForegroundColor Yellow
+    Write-Host ('    min-release-age = (npm v11.10 以降で利用可能。現在 v' + $npmVersionStr + ')') -ForegroundColor DarkGray
 }
 
 Write-Host ''
-if ($ignoreOk -and $ageOk) {
+if ($ignoreOk -and ($ageOk -or -not $npmSupportsAge)) {
     Write-Host '    この PC の npm 防御設定は適用済みです。' -ForegroundColor Green
+    if (-not $npmSupportsAge) {
+        Write-Host '    ※ min-release-age は npm v11.10 以降で利用可能です。npm のアップグレードを推奨します。' -ForegroundColor DarkGray
+    }
 } else {
     Write-Host '    以下のコマンドで、今後の攻撃に備えてください:' -ForegroundColor Yellow
     Write-Host ''
     if (-not $ignoreOk) {
         Write-Host '      npm config set ignore-scripts true' -ForegroundColor White
     }
-    if (-not $ageOk) {
+    if (-not $ageOk -and $npmSupportsAge) {
         Write-Host '      npm config set min-release-age 7' -ForegroundColor White
+    }
+    if (-not $npmSupportsAge) {
+        Write-Host '      npm のアップグレード後: npm config set min-release-age 7  (v11.10 以降)' -ForegroundColor DarkGray
     }
     Write-Host ''
     Write-Host '    詳細は AuditVerdict.txt の「今後の防御策」セクションを参照。' -ForegroundColor DarkGray

--- a/axios_audit_stage6_verdict.ps1
+++ b/axios_audit_stage6_verdict.ps1
@@ -308,6 +308,15 @@ if ($systemCompromised -or $countCompromised -gt 0) {
 [void]$report.Add('  以下の設定はパッケージ名に関係なく、npm 全体に効きます。')
 [void]$report.Add('')
 
+# npm バージョンを取得して min-release-age の対応可否を判定
+$npmVersionStr = $null
+try { $npmVersionStr = (& npm --version 2>$null) } catch {}
+$npmSupportsAge = $false
+if ($npmVersionStr -match '^(\d+)\.(\d+)') {
+    $npmMajor = [int]$Matches[1]; $npmMinor = [int]$Matches[2]
+    $npmSupportsAge = ($npmMajor -gt 11 -or ($npmMajor -eq 11 -and $npmMinor -ge 10))
+}
+
 # npm の現在の設定を確認
 $currentIgnoreScripts = $null
 $currentMinReleaseAge = $null
@@ -315,7 +324,9 @@ try {
     $savedEAP = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'
     $currentIgnoreScripts = (& npm config get ignore-scripts 2>$null)
-    $currentMinReleaseAge = (& npm config get min-release-age 2>$null)
+    if ($npmSupportsAge) {
+        $currentMinReleaseAge = (& npm config get min-release-age 2>$null)
+    }
     $ErrorActionPreference = $savedEAP
 } catch {
     $ErrorActionPreference = $savedEAP
@@ -345,16 +356,22 @@ if ($currentIgnoreScripts -eq 'true') {
 [void]$report.Add('    公開から一定日数が経過していないバージョンのインストールを拒否します。')
 [void]$report.Add('    今回の侵害版は約3時間で削除されたので、7日待てば絶対に踏みません。')
 [void]$report.Add('')
-if ($currentMinReleaseAge -and $currentMinReleaseAge -ne 'undefined' -and $currentMinReleaseAge -ne '0') {
-    [void]$report.Add('    現在の設定: min-release-age = ' + $currentMinReleaseAge + '  ✓ 設定済み')
+if ($npmSupportsAge) {
+    if ($currentMinReleaseAge -and $currentMinReleaseAge -ne 'undefined' -and $currentMinReleaseAge -ne '0') {
+        [void]$report.Add('    現在の設定: min-release-age = ' + $currentMinReleaseAge + '  ✓ 設定済み')
+    } else {
+        [void]$report.Add('    現在の設定: min-release-age = ' + $(if ($currentMinReleaseAge) { $currentMinReleaseAge } else { '(未設定)' }) + '  ✗ 未設定')
+        [void]$report.Add('')
+        [void]$report.Add('    設定コマンド:')
+        [void]$report.Add('      npm config set min-release-age 7')
+        [void]$report.Add('')
+        [void]$report.Add('    ※ 緊急パッチを即座に適用したい場合は都度:')
+        [void]$report.Add('      npm install パッケージ名 --min-release-age=0')
+    }
 } else {
-    [void]$report.Add('    現在の設定: min-release-age = ' + $(if ($currentMinReleaseAge) { $currentMinReleaseAge } else { '(未設定)' }) + '  ✗ 未設定')
-    [void]$report.Add('')
-    [void]$report.Add('    設定コマンド（npm v11.10 以降）:')
+    [void]$report.Add('    この機能は npm v11.10 以降で利用可能です（現在 v' + $npmVersionStr + '）。')
+    [void]$report.Add('    npm をアップグレード後に以下を実行してください:')
     [void]$report.Add('      npm config set min-release-age 7')
-    [void]$report.Add('')
-    [void]$report.Add('    ※ 緊急パッチを即座に適用したい場合は都度:')
-    [void]$report.Add('      npm install パッケージ名 --min-release-age=0')
 }
 [void]$report.Add('')
 
@@ -368,14 +385,27 @@ if ($currentMinReleaseAge -and $currentMinReleaseAge -ne 'undefined' -and $curre
 
 [void]$report.Add('  [まとめ] いますぐ実行すべきコマンド（この PC 全体に適用）:')
 [void]$report.Add('')
-$alreadyDone = ($currentIgnoreScripts -eq 'true') -and ($currentMinReleaseAge -and $currentMinReleaseAge -ne 'undefined' -and $currentMinReleaseAge -ne '0')
+$ignoreScriptsOk = ($currentIgnoreScripts -eq 'true')
+$minReleaseAgeOk = $npmSupportsAge -and ($currentMinReleaseAge -and $currentMinReleaseAge -ne 'undefined' -and $currentMinReleaseAge -ne '0')
+$alreadyDone = $ignoreScriptsOk -and ($minReleaseAgeOk -or -not $npmSupportsAge)
 if ($alreadyDone) {
-    [void]$report.Add('    ✓ この PC では防御策 A / B とも設定済みです。追加操作は不要です。')
+    [void]$report.Add('    ✓ この PC では防御設定が適用済みです。')
+    if (-not $npmSupportsAge) {
+        [void]$report.Add('    ※ min-release-age は npm v11.10 以降で利用可能です。npm のアップグレードを推奨します。')
+    }
 } else {
-    [void]$report.Add('    npm config set ignore-scripts true')
-    [void]$report.Add('    npm config set min-release-age 7')
+    if (-not $ignoreScriptsOk) {
+        [void]$report.Add('    npm config set ignore-scripts true')
+    }
+    if ($npmSupportsAge) {
+        if (-not $minReleaseAgeOk) {
+            [void]$report.Add('    npm config set min-release-age 7')
+        }
+    } else {
+        [void]$report.Add('    npm のアップグレード後: npm config set min-release-age 7  (v11.10 以降)')
+    }
     [void]$report.Add('')
-    [void]$report.Add('    この 2 行だけで、今回の axios 攻撃を含むほとんどの')
+    [void]$report.Add('    これにより、今回の axios 攻撃を含むほとんどの')
     [void]$report.Add('    npm サプライチェーン攻撃を防げます。')
 }
 [void]$report.Add('')
@@ -423,12 +453,22 @@ Write-Host ''
 if (-not $alreadyDone) {
     Write-Host '  [推奨] この PC の npm を今後の攻撃に備えて強化してください:' -ForegroundColor Yellow
     Write-Host ''
-    Write-Host '    npm config set ignore-scripts true' -ForegroundColor White
-    Write-Host '    npm config set min-release-age 7' -ForegroundColor White
+    if (-not $ignoreScriptsOk) {
+        Write-Host '    npm config set ignore-scripts true' -ForegroundColor White
+    }
+    if ($npmSupportsAge -and -not $minReleaseAgeOk) {
+        Write-Host '    npm config set min-release-age 7' -ForegroundColor White
+    }
+    if (-not $npmSupportsAge) {
+        Write-Host '    npm のアップグレード後: npm config set min-release-age 7  (v11.10 以降)' -ForegroundColor DarkGray
+    }
     Write-Host ''
     Write-Host '    詳細は AuditVerdict.txt の「今後の防御策」セクションを参照。' -ForegroundColor DarkGray
 } else {
-    Write-Host '  [OK] npm の防御設定（ignore-scripts / min-release-age）は設定済みです。' -ForegroundColor Green
+    Write-Host '  [OK] npm の防御設定は適用済みです。' -ForegroundColor Green
+    if (-not $npmSupportsAge) {
+        Write-Host '  ※ min-release-age は npm v11.10 以降で利用可能です。npm のアップグレードを推奨します。' -ForegroundColor DarkGray
+    }
 }
 Write-Host ''
 Write-Host ('  詳細: ' + $verdictTxt)

--- a/axios_audit_stage7_remediate.ps1
+++ b/axios_audit_stage7_remediate.ps1
@@ -183,7 +183,7 @@ if ($actions.Count -gt 0) {
 [void]$manualActions.Add('         postinstall が必要なパッケージは個別に: npm rebuild パッケージ名')
 [void]$manualActions.Add('')
 [void]$manualActions.Add('     [重要] 新しいバージョンの即時採用を避ける（クールダウン）:')
-[void]$manualActions.Add('       npm config set min-release-age 7')
+[void]$manualActions.Add('       npm config set min-release-age 7    ※ npm v11.10 以降で利用可能')
 [void]$manualActions.Add('')
 [void]$manualActions.Add('       → 公開から 7 日以内のバージョンのインストールを拒否します。')
 [void]$manualActions.Add('         今回の侵害版は約 3 時間で削除されたので、7 日待てば踏みません。')


### PR DESCRIPTION
## Summary
- npm v11.10 未満では `min-release-age` が未対応でエラーになる問題に対応
- npm バージョンを自動判定し、未対応の場合は「npm のアップグレード後に設定」と案内
- `ignore-scripts` のみ設定済みなら「防御設定適用済み」と判定（npm が古い場合）
- README に Stage 7/8 未検証の注意事項を追加

影響ファイル: `run_all.ps1`, `stage6_verdict.ps1`, `stage7_remediate.ps1`, `README.md`

## Test plan
- [ ] npm v11.10 未満の環境で実行し、`min-release-age` でエラーが出ないこと
- [ ] npm v11.10 未満では「npm のアップグレード後に設定」と案内されること
- [ ] npm v11.10 以降では従来通り設定状態が表示されること
- [ ] `ignore-scripts = true` のみ設定済み + npm 古い環境で「防御設定適用済み」と表示されること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)