### PR TITLE
Q&A: npm だけのアップグレード方法を追記

### DIFF
--- a/axios_audit_manual.md
+++ b/axios_audit_manual.md
@@ -574,7 +574,13 @@ npm install パッケージ名 --min-release-age=0
 npm --version
 ```
 
-でバージョンを確認し、古い場合は Node.js ごとアップグレードしてください：
+でバージョンを確認し、v11.10 未満の場合は npm だけをアップグレードしてください（Node.js はそのままで OK）：
+
+```
+npm install -g npm@latest
+```
+
+Node.js が古い場合（v18 未満など）は Node.js ごとアップグレードしてください：
 
 ```
 # Node.js 公式サイトから LTS 版をインストール（npm も同梱）


### PR DESCRIPTION
## Summary
- `npm install -g npm@latest` で npm だけアップグレードすれば `min-release-age` が使えることを Q&A に追記
- Node.js ごとアップグレードは Node.js 自体が古い場合のみ必要と整理

## Test plan
- [ ] マニュアルの Q&A が正しく表示されること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)