### PR TITLE
fix: nvm-windows 環境での npm 検出失敗と StrictMode 競合を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 - **シェル:** Windows PowerShell 5.1 以降（Windows 標準搭載）
 - **ファイルシステム:** システムロケールが Shift_JIS（cp932）の標準的な日本語 Windows 環境で動作します。スクリプト自体は UTF-8 BOM + CRLF で保存されています。
 - **npm:** Node.js / npm がインストール済みであること（バージョン確認・修復に使用）。npm がなくてもプロジェクト棚卸しと IOC 確認は実行できます。
+- **nvm-windows 利用時の注意:** nvm-windows 経由で Node.js を管理している場合、PowerShell 5.1 のスクリプト実行コンテキストでは npm に PATH が通らないことがあります。スクリプトは環境変数 `NVM_SYMLINK` / `NVM_HOME` を参照して自動的に PATH を補完しますが、それでも npm が見つからない場合は、スクリプト実行前に手動で PATH を追加してください：
+  ```powershell
+  $env:PATH = "$env:NVM_SYMLINK;$env:PATH"
+  ```
 
 ## インストール
 

--- a/axios_audit_run_all.ps1
+++ b/axios_audit_run_all.ps1
@@ -441,8 +441,10 @@ $cfgAge = $null
 try {
     $savedEAP = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'
+    Set-StrictMode -Off
     $cfgIgnore = (& npm config get ignore-scripts 2>$null)
     $cfgAge = (& npm config get min-release-age 2>$null)
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = $savedEAP
 } catch {
     $ErrorActionPreference = $savedEAP
@@ -458,7 +460,7 @@ if ($ignoreOk) {
 }
 # npm バージョンを取得して min-release-age の対応可否を判定
 $npmVersionStr = $null
-try { $npmVersionStr = (& npm --version 2>$null) } catch {}
+try { Set-StrictMode -Off; $npmVersionStr = (& npm --version 2>$null) } catch {} finally { Set-StrictMode -Version Latest }
 $npmSupportsAge = $false
 if ($npmVersionStr -match '^(\d+)\.(\d+)') {
     $npmMajor = [int]$Matches[1]; $npmMinor = [int]$Matches[2]

--- a/axios_audit_stage3_check_versions.ps1
+++ b/axios_audit_stage3_check_versions.ps1
@@ -53,11 +53,29 @@ function Add-Result {
     $stats.Findings++
 }
 
+# nvm for Windows が管理する Node.js パスを PATH に追加
+# PowerShell 5.1 から直接実行すると nvm-windows の PATH 注入が効かないため
+$nvmSymlink = if ($env:NVM_SYMLINK) { $env:NVM_SYMLINK } else { '' }
+$nvmHome    = if ($env:NVM_HOME)    { $env:NVM_HOME }    else { '' }
+if ($nvmSymlink -and (Test-Path $nvmSymlink)) {
+    $env:PATH = "$nvmSymlink;$env:PATH"
+} elseif ($nvmHome) {
+    $currentLink = Join-Path $nvmHome 'nodejs'
+    if (Test-Path $currentLink) {
+        $env:PATH = "$currentLink;$env:PATH"
+    }
+}
+
+# nvm-windows の npm.ps1 ラッパーが $MyInvocation.Statement を参照するため
+# StrictMode Latest だとエラーになる。npm 呼び出し時のみ緩和する。
 $npmAvailable = $true
 try {
+    Set-StrictMode -Off
     & npm --version *> $null
 } catch {
     $npmAvailable = $false
+} finally {
+    Set-StrictMode -Version Latest
 }
 
 $index = 0
@@ -95,7 +113,9 @@ foreach ($root in $roots) {
         $savedEnc = [Console]::OutputEncoding
         $ErrorActionPreference = 'Continue'
         [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+        Set-StrictMode -Off          # nvm-windows npm.ps1 ラッパー対策
         $raw = (& npm list axios --all 2>&1 | Out-String)
+        Set-StrictMode -Version Latest
         [Console]::OutputEncoding = $savedEnc
         $ErrorActionPreference = $savedEAP
 

--- a/axios_audit_stage4_logs_ioc.ps1
+++ b/axios_audit_stage4_logs_ioc.ps1
@@ -83,7 +83,9 @@ $candidateCaches = New-Object System.Collections.ArrayList
 try {
     $savedEnc = [Console]::OutputEncoding
     [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+    Set-StrictMode -Off
     $npmCache = (& npm config get cache 2>$null)
+    Set-StrictMode -Version Latest
     [Console]::OutputEncoding = $savedEnc
     if ($LASTEXITCODE -eq 0 -and $npmCache) {
         $trimmed = $npmCache.ToString().Trim()
@@ -152,7 +154,9 @@ try {
     $savedEnc = [Console]::OutputEncoding
     $ErrorActionPreference = 'Continue'
     [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+    Set-StrictMode -Off
     (& npm ls -g --depth=8 2>&1 | Out-String) | Out-File -FilePath $globalTxt -Encoding UTF8
+    Set-StrictMode -Version Latest
     [Console]::OutputEncoding = $savedEnc
     $ErrorActionPreference = $savedEAP
 } catch {

--- a/axios_audit_stage6_verdict.ps1
+++ b/axios_audit_stage6_verdict.ps1
@@ -310,7 +310,7 @@ if ($systemCompromised -or $countCompromised -gt 0) {
 
 # npm バージョンを取得して min-release-age の対応可否を判定
 $npmVersionStr = $null
-try { $npmVersionStr = (& npm --version 2>$null) } catch {}
+try { Set-StrictMode -Off; $npmVersionStr = (& npm --version 2>$null) } catch {} finally { Set-StrictMode -Version Latest }
 $npmSupportsAge = $false
 if ($npmVersionStr -match '^(\d+)\.(\d+)') {
     $npmMajor = [int]$Matches[1]; $npmMinor = [int]$Matches[2]
@@ -323,12 +323,15 @@ $currentMinReleaseAge = $null
 try {
     $savedEAP = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'
+    Set-StrictMode -Off
     $currentIgnoreScripts = (& npm config get ignore-scripts 2>$null)
     if ($npmSupportsAge) {
         $currentMinReleaseAge = (& npm config get min-release-age 2>$null)
     }
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = $savedEAP
 } catch {
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = $savedEAP
 }
 


### PR DESCRIPTION
## Summary
- nvm-windows 環境で PowerShell 5.1 スクリプト実行時に npm へ PATH が通らない問題を修正（`NVM_SYMLINK` / `NVM_HOME` 環境変数から自動補完）
- nvm-windows の `npm.ps1` ラッパーが `Set-StrictMode -Version Latest` 下で `$MyInvocation.Statement` プロパティエラーになる問題を修正（npm 呼び出し時のみ StrictMode を緩和）
- README に nvm-windows 利用時の注意事項を追記

Fixes #9, Fixes #10

## Test plan
- [x] nvm-windows 環境で Stage 3 から再実行し、npm が正常に検出されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)